### PR TITLE
ci: add terraform github action workflows

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,49 @@
+# .github/workflows/terraform-apply.yml
+name: "Terraform Apply"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.tf"
+      - "**.py"
+      - ".github/workflows/terraform-apply.yml"
+
+jobs:
+  terraform-apply:
+    name: "Terraform Apply"
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Plan
+        run: terraform plan -var="phone_number=${{ secrets.PHONE_NUMBER }}" -var="email_address=${{ secrets.EMAIL_ADDRESS }}"
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve -var="phone_number=${{ secrets.PHONE_NUMBER }}" -var="email_address=${{ secrets.EMAIL_ADDRESS }}"
+
+      - name: Output API Gateway URL
+        run: |
+          echo "🐢 Apapp alert system deployed!"
+          terraform output -raw qr_code_url
+          echo ""
+          echo "Use this URL to generate your QR codes."

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -1,0 +1,39 @@
+# .github/workflows/terraform-destroy.yml
+name: "Terraform Destroy"
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_destroy:
+        description: 'Type "destroy" to confirm'
+        required: true
+        default: ""
+
+jobs:
+  terraform-destroy:
+    name: "Terraform Destroy"
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.event.inputs.confirm_destroy == 'destroy'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Destroy
+        run: terraform destroy -auto-approve -var="phone_number=${{ secrets.PHONE_NUMBER }}" -var="email_address=${{ secrets.EMAIL_ADDRESS }}"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,42 @@
+# .github/workflows/terraform-plan.yml
+name: "Terraform Plan"
+
+on:
+  pull_request:
+    paths:
+      - "**.tf"
+      - "**.py"
+      - ".github/workflows/terraform-plan.yml"
+
+jobs:
+  terraform-plan:
+    name: "Terraform Plan"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Terraform Format Check
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Terraform Plan
+        run: terraform plan -var="phone_number=${{ secrets.PHONE_NUMBER }}" -var="email_address=${{ secrets.EMAIL_ADDRESS }}"


### PR DESCRIPTION
Adds three GitHub Action workflows for managing Terraform infrastructure:

- Apply workflow: Automatically deploys infrastructure on main branch pushes
- Plan workflow: Runs format check, validation and plan on pull requests
- Destroy workflow: Manual trigger to safely tear down infrastructure

Configures AWS credentials and includes secret management for sensitive variables. Implements proper environment protection for production deployments. Adds output of QR code URL after successful deployment for easy access.